### PR TITLE
[WIP] Ensure references_many no nil value

### DIFF
--- a/lib/ledger_sync/resource_attribute.rb
+++ b/lib/ledger_sync/resource_attribute.rb
@@ -34,8 +34,6 @@ module LedgerSync
     end
 
     def assert_valid(args = {})
-      ensure_references_many_value_presence(args)
-
       value = args.fetch(:value)
 
       type.assert_valid(value: value)
@@ -73,12 +71,6 @@ module LedgerSync
     def will_change?(val)
       assert_valid(value: val)
       value != type.cast(value: val)
-    end
-
-    def ensure_references_many_value_presence(args)
-      if references_many? && args.fetch(:value).nil?
-        args[:value] = []
-      end
     end
   end
 end

--- a/lib/ledger_sync/resource_attribute.rb
+++ b/lib/ledger_sync/resource_attribute.rb
@@ -34,6 +34,8 @@ module LedgerSync
     end
 
     def assert_valid(args = {})
+      ensure_references_many_value_presence(args)
+
       value = args.fetch(:value)
 
       type.assert_valid(value: value)
@@ -71,6 +73,12 @@ module LedgerSync
     def will_change?(val)
       assert_valid(value: val)
       value != type.cast(value: val)
+    end
+
+    def ensure_references_many_value_presence(args)
+      if references_many? && args.fetch(:value).nil?
+        args[:value] = []
+      end
     end
   end
 end

--- a/lib/ledger_sync/serialization/type/deserializer_references_many_type.rb
+++ b/lib/ledger_sync/serialization/type/deserializer_references_many_type.rb
@@ -11,7 +11,7 @@ module LedgerSync
           value                  = args.fetch(:value)
           resource               = args.fetch(:resource)
 
-          return if value.nil?
+          return [] if value.nil?
 
           first_dot = deserializer_attribute.resource_attribute_dot_parts.first.to_sym
           nested_resource = resource.class.resource_attributes[first_dot].type.resource_class.new

--- a/lib/ledger_sync/type/value_mixin.rb
+++ b/lib/ledger_sync/type/value_mixin.rb
@@ -22,7 +22,6 @@ module LedgerSync
       # Do not override this method.  Override private method cast_value
       def cast(args = {})
         assert_valid(args)
-        return nil if args.fetch(:value).nil?
 
         cast_value(args)
       end

--- a/spec/deserializer/acceptance_artifact_spec.rb
+++ b/spec/deserializer/acceptance_artifact_spec.rb
@@ -1,0 +1,57 @@
+# Usage: bundle exec rspec spec/deserializer/acceptance_artifact_spec.rb
+
+require 'ledger_sync'
+require 'rspec'
+
+class Package < LedgerSync::Resource
+  attribute :blabla, type: LedgerSync::Type::String
+end
+
+class Package
+  class Deserializer < LedgerSync::Deserializer
+    attribute :blabla, hash_attribute: :blabla
+  end
+end
+
+class AcceptanceArtifact < LedgerSync::Resource
+  attribute :identifier, type: LedgerSync::Type::String
+  references_many :packages, to: Package
+end
+
+class AcceptanceArtifact
+  class Deserializer < LedgerSync::Deserializer
+    attribute :identifier, hash_attribute: :identifier
+    references_many :packages, deserializer: Package::Deserializer,  hash_attribute: :packages
+  end
+end
+
+RSpec.describe AcceptanceArtifact::Deserializer do
+  describe '#deserialize' do
+    let(:deserializer) { described_class.new }
+    let(:acceptance_artifact) { AcceptanceArtifact.new }
+
+    subject(:deserialized_object) { deserializer.deserialize(hash: response, resource: acceptance_artifact) }
+
+    context "with packages in the API's response" do
+      let(:response) { { "identifier" => "42", "packages" => [] } }
+
+      it 'deserializes the identifier correctly' do
+        expect(deserialized_object.identifier).to eq("42")
+      end
+    end
+
+    context "without packages in the API's response" do
+      let(:response) { { "identifier" => "42" } }
+
+      it 'deserializes the packages correctly' do
+        expect(deserialized_object.packages).to eq([])
+      end
+    end
+  end
+end
+
+# Manual trigger
+# deserializer = AcceptanceArtifact::Deserializer.new
+# response_1 = { "identifier" => "42", "packages" => [] }
+# response_2 = { "identifier" => "42" }
+# accept_art = deserializer.deserialize(hash: response_1, resource: AcceptanceArtifact.new)

--- a/spec/deserializer/acceptance_artifact_spec.rb
+++ b/spec/deserializer/acceptance_artifact_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AcceptanceArtifact::Deserializer do
 
     subject(:deserialized_object) { deserializer.deserialize(hash: response, resource: acceptance_artifact) }
 
-    context "with packages in the API's response" do
+    context "with empty `packages` in the API's response" do
       let(:response) { { "identifier" => "42", "packages" => [] } }
 
       it 'deserializes the identifier correctly' do
@@ -40,7 +40,15 @@ RSpec.describe AcceptanceArtifact::Deserializer do
       end
     end
 
-    context "without packages in the API's response" do
+    context "with filled `packages` in the API's response" do
+      let(:response) { { "identifier" => "42", "packages" => [ { "blabla" => "ok" } ] } }
+
+      it 'deserializes the identifier correctly' do
+        expect(deserialized_object.identifier).to eq("42")
+      end
+    end
+
+    context "without `packages` in the API's response" do
       let(:response) { { "identifier" => "42" } }
 
       it 'deserializes the packages correctly' do


### PR DESCRIPTION
### **Issue:**
When we have a deserializer with a `references_many` inside and that we don't receive this value in the response of the API call, it crashes.

### **What we want:**
When we have a deserializer with a `references_many` inside and that we don't receive this value in the response of the API call, it should just ignore it and continue reading next attributes as it works for `references_one` and `attribute`.

### **What's happening concretely in the code:**
While deserializing, while arriving on a non existing `reference_many` in the response, we `.assign_attribute` the `reference_many` with a `nil` value. This causes the crash (`lib/ledger_sync/deserializer.rb:44`).

### **What's the plan:**
Maybe try to set the value to `[]` (empty array) when the reference is not present in the response.

### **Example:**
![Screenshot from 2024-08-31 15-20-22](https://github.com/user-attachments/assets/34d77b32-87b0-4164-af4e-6865a2c1ca0a)
![Screenshot from 2024-08-31 15-20-59](https://github.com/user-attachments/assets/15877e16-64f5-4777-aea7-590472cafa9f)


When I receive the answer from my API call on AmazonBusinessAPI, sometimes, it doesn't have the "packages" `key` with an array as `value`, like that:
```ruby
# Response from API with `packages`
deserializer = AmazonBusinessApi::AcceptanceArtifact::Deserializer.new
response = { "identifier" => "42", "packages" => [] }
accept_art = deserializer.deserialize(hash: response, resource: AmazonBusinessApi::AcceptanceArtifact.new)
=> Success

# Response from API call without `packages`
deserializer = AmazonBusinessApi::AcceptanceArtifact::Deserializer.new
response = { "identifier" => "42" }
accept_art = deserializer.deserialize(hash: response, resource: AmazonBusinessApi::AcceptanceArtifact.new)
=> .../ledger_sync/lib/ledger_sync/error/resource_errors.rb:23:in `generate_message': undefined method `reject' for nil:NilClass (NoMethodError)
=> invalid_classes = value.reject { |e| e.is_a?(type_resource_class) }.map(&:class)
```

In the first case, everything works fine. In the second case, the gem searches for `packages`, doesn't find it and crashes.